### PR TITLE
Remove querystring

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: ''
-assignees: ''
+assignees: 'aramshiva'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: ''
 labels: ''
-assignees: ''
+assignees: 'aramshiva'
 
 ---
 

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "tabWidth": 2,
+  "useTabs": false
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "eslint-config-next": "^14.0.4",
     "framer-motion": "^10.17.6",
     "next": "^14.0.4",
-    "querystring": "^0.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.12.0",

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-export default function Example() {
+export default function Error() {
   return (
     <>
       <main className="grid min-h-full place-items-center px-6 py-9 sm:py-20 lg:px-5 h-screen">

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,10 +1,12 @@
 import { AppProps } from "next/app";
 import "../styles/index.css";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   // return <div className="bg-white dark:bg-gray-800 text-slate-900 dark:text-white"><Component {...pageProps} /></div>
   return (
     <div>
+      <SpeedInsights />
       <Component {...pageProps} />
     </div>
   );

--- a/pages/api/spotify.ts
+++ b/pages/api/spotify.ts
@@ -1,5 +1,3 @@
-import querystring from "querystring";
-
 const {
   SPOTIFY_CLIENT_ID: client_id,
   SPOTIFY_CLIENT_SECRET: client_secret,
@@ -17,7 +15,7 @@ const getAccessToken = async () => {
       Authorization: `Basic ${basic}`,
       "Content-Type": "application/x-www-form-urlencoded",
     },
-    body: querystring.stringify({
+    body: new URLSearchParams({
       grant_type: "refresh_token",
       refresh_token,
     }),

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,24 +2,20 @@ import Container from "../components/container";
 import { Typewriter } from "react-simple-typewriter";
 import Layout from "../components/layout";
 import { Inter } from "next/font/google";
-import useSWR from "swr";
-import Link from "next/link";
 import SpotifyWidget from "../components/spotifynowplaying";
 
 const inter = Inter({ subsets: ["latin"] });
 
 export default function Index() {
-  const fetcher = (url) => fetch(url).then((r) => r.json());
-  const { data } = useSWR("/api/spotify", fetcher);
   return (
     <>
       <div>
         <Layout>
           <Container>
             <div className="h-20" />
-            <div className="text-7xl font-semibold">
+            <div className="text-5xl font-semibold">
               <span>
-                Aram is a{" "}
+                I am a{" "}
                 <span>
                   <Typewriter
                     words={[
@@ -44,7 +40,12 @@ export default function Index() {
               {"  "}
               <p></p>
             </div>
-            <div className="text-xl font-normal">
+            <div className="textl-xl">
+              <div>
+                <span className="wave">👋</span> I create remarkable experiences
+                for the web.
+              </div>
+
             </div>
             <SpotifyWidget />
           </Container>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -44,8 +44,7 @@ export default function Index() {
               {"  "}
               <p></p>
             </div>
-            <div className="text-lg font-normal">
-              Aram is a student building remarkable things
+            <div className="text-xl font-normal">
             </div>
             <SpotifyWidget />
           </Container>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3755,11 +3755,6 @@ punycode@^2.1.0:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-querystring@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.1.tgz#40d77615bb09d16902a85c3e38aa8b5ed761c2dd"
-  integrity sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==
-
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"


### PR DESCRIPTION
The `querystring` library is deprecated, instead replacing it with the built-in `URLSearchParams`. This also adds the vercel `SpeedInsights` Module